### PR TITLE
Removed dependency to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ step when the build tool "Download the whole internet"
 ```yaml
 build:
   steps:
-    - ernoaapa/cache:
+    - sharpershape/cache:
       name: "Restore dependencies from cache"
       action: restore
 
     # ... your steps here ...
 
-    - ernoaapa/cache:
+    - sharpershape/cache:
       name: "Store dependencies to cache"
       action: store
 ```
@@ -28,6 +28,9 @@ build:
 The MIT License (MIT)
 
 # Changelog
+## 0.3.0
+- Removed custom separator to remove bash dependency
+
 ## 0.2.0
 - Fixed the script
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #========================================================
 # Script for storing and restoring cached directories
@@ -6,12 +6,7 @@
 # See http://devcenter.wercker.com/docs/pipelines/wercker-cache.html
 #========================================================
 
-WERCKER_CACHE_SEPARATOR=${WERCKER_CACHE_SEPARATOR:-" "}
-
 main() {
-  IFS=$WERCKER_CACHE_SEPARATOR directories=($WERCKER_CACHE_DIRECTORIES)
-
-  # set source and destination directories
   case $WERCKER_CACHE_ACTION in
     "store")
       SRC=$HOME
@@ -24,7 +19,7 @@ main() {
   esac
 
   # run rsync
-  for directory in "${directories[@]}"; do
+  for directory in $WERCKER_CACHE_DIRECTORIES; do
     if test -d "${SRC}/${directory}"; then
       echo "sync ${SRC}/${directory} ${DST}/"
       rsync -avz "${SRC}/${directory}" "${DST}/"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -13,8 +13,3 @@ properties:
     type: string
     required: false
     default: .m2 .ivy2 .sbt
-  # Separator for above directories -list
-  separator:
-    type: string
-    required: false
-    default: " "


### PR DESCRIPTION
Removed custom separator (what were not used), to
get rid of dependency to bash array syntax.
Now this step can be used in containers where is no bash available.